### PR TITLE
Unify errors into one rescueable Linkscape::Error

### DIFF
--- a/lib/linkscape/client.rb
+++ b/lib/linkscape/client.rb
@@ -134,10 +134,18 @@ module Linkscape
       Linkscape::Request.run(@options.merge(options))
     end
 
+    def last_update
+      Linkscape::Request.run_raw(@options.merge(:api => 'metadata/last_update'))
+    end
+
     def status(*args)
       options = Hash === args.last ? args.pop.symbolize_keys : {}
       options[:api] = 'status'
       Linkscape::Request.run(@options.merge(options))
+    end
+
+    def last_update
+      Linkscape::Request.run_raw(@options.merge(:api => 'metadata/last_update')).to_i
     end
 
 

--- a/lib/linkscape/client.rb
+++ b/lib/linkscape/client.rb
@@ -134,10 +134,6 @@ module Linkscape
       Linkscape::Request.run(@options.merge(options))
     end
 
-    def last_update
-      Linkscape::Request.run_raw(@options.merge(:api => 'metadata/last_update'))
-    end
-
     def status(*args)
       options = Hash === args.last ? args.pop.symbolize_keys : {}
       options[:api] = 'status'
@@ -147,7 +143,6 @@ module Linkscape
     def last_update
       Linkscape::Request.run_raw(@options.merge(:api => 'metadata/last_update')).to_i
     end
-
 
     def anchorMetrics(*args)
       options = Hash === args.last ? args.pop.symbolize_keys : {}

--- a/lib/linkscape/constants.rb
+++ b/lib/linkscape/constants.rb
@@ -411,10 +411,15 @@ module Linkscape
         :key => :text,
         :desc => %Q[The Anchor Text term or phrase],
       },
-      :i => {
+      :rid => {
         :name => 'Internal Target ID',
         :key => :record_id,
         :desc => %Q[Internal ID of the target URL],
+      },
+      :i => {
+        :name => 'Internal Target Domain ID',
+        :key => :pl_domain_id,
+        :desc => %Q[Internal ID of the target PL Domain],
       },
       :iu => {
         :name => 'Internal Pages Linking',

--- a/lib/linkscape/constants/anchor-metrics.rb
+++ b/lib/linkscape/constants/anchor-metrics.rb
@@ -3,15 +3,20 @@ module Linkscape
     module AnchorMetrics
 
       RequestBits = {
+        :record_id => {
+          :name => 'record_id',
+          :flag => 2**0, # 1
+          :desc => %Q[Internal record ID of the target]
+        },
         :text => {
           :name => 'text',
           :flag => 2**1, # 2
           :desc => %Q[The anchor text term or phrase]
         },
-        :record_id => {
-          :name => 'record_id',
+        :pl_domain_id => {
+          :name => 'pl_domain_id',
           :flag => 2**2, # 4
-          :desc => %Q[Internal record ID of the target]
+          :desc => %Q[Internal record ID of the target's domain]
         },
         :internal_pages_linking => {
           :name => 'Internal Pages Linking',

--- a/lib/linkscape/errors.rb
+++ b/lib/linkscape/errors.rb
@@ -1,4 +1,14 @@
-class RecursionError < StandardError; end
+module Linkscape
+  class Error < ::StandardError; end
+
+  class HTTPStatusError < Error; end
+  class InternalServerError < HTTPStatusError; end
+  class TimeoutError < Error; end
+  class EOFError < Error; end
+
+  class RecursionError < Error; end
+end
+
 class AuthenticationError < StandardError; end
 class InvalidArgument < StandardError; end
 class MissingArgument < StandardError; end

--- a/lib/linkscape/request.rb
+++ b/lib/linkscape/request.rb
@@ -90,7 +90,7 @@ module Linkscape
       raise Linkscape::TimeoutError
     rescue EOFError => e
       raise Linkscape::EOFError
-    rescue SystemCallException, Net::HTTPBadResponse, Net::HTTPHeaderSyntaxError, Net::ProtocolError, SocketError => e
+    rescue SystemCallError, Net::HTTPBadResponse, Net::HTTPHeaderSyntaxError, Net::ProtocolError, SocketError => e
       raise Linkscape::Error, "#{e.class}: #{e.message}"
     end
 

--- a/lib/linkscape/request.rb
+++ b/lib/linkscape/request.rb
@@ -88,7 +88,7 @@ module Linkscape
 
     rescue Timeout::Error, Timeout::ExitException => e
       raise Linkscape::TimeoutError
-    rescue EOFError => e
+    rescue ::EOFError => e
       raise Linkscape::EOFError
     rescue SystemCallError, Net::HTTPBadResponse, Net::HTTPHeaderSyntaxError, Net::ProtocolError, SocketError => e
       raise Linkscape::Error, "#{e.class}: #{e.message}"

--- a/lib/linkscape/request.rb
+++ b/lib/linkscape/request.rb
@@ -47,6 +47,10 @@ module Linkscape
 
       options[:limit] = 1000 if options[:limit] && options[:limit] > 1000
       @requestURL += "&Limit=#{options[:limit]}" if options[:limit]
+      
+      [:AnchorPhraseRid, :AnchorTermRid, :SourceDomain].each do |key|
+        @requestURL += "&#{key}=#{options[key]}" if options[key]
+      end
     end
     
     def run

--- a/lib/linkscape/request.rb
+++ b/lib/linkscape/request.rb
@@ -77,7 +77,7 @@ module Linkscape
       end
       
       if response.is_a? Net::HTTPRedirection
-        fetch(response['location'], limit - 1)
+        fetch(URI.parse(response['location']), limit - 1)
       elsif response.is_a? Net::HTTPOK
         response
       elsif response.is_a? Net::HTTPInternalServerError

--- a/lib/linkscape/request.rb
+++ b/lib/linkscape/request.rb
@@ -15,6 +15,10 @@ module Linkscape
     def self.run(options)
       self.new(options).run
     end
+
+    def self.run_raw(options)
+      self.new(options).run_raw
+    end
     
     def initialize(options)
      
@@ -49,6 +53,10 @@ module Linkscape
       res = fetch(URI.parse(@requestURL))
       # res = fetch(URI.parse('http://martian.at/other/ose.json'))
       return Response.new(self, res)
+    end
+
+    def run_raw
+      fetch(URI.parse(@requestURL)).body
     end
 
     def inspect

--- a/lib/linkscape/request.rb
+++ b/lib/linkscape/request.rb
@@ -76,7 +76,7 @@ module Linkscape
         Net::HTTP.get_response(uri)
       end
       
-      if response_is_a? Net::HTTPRedirection
+      if response.is_a? Net::HTTPRedirection
         fetch(response['location'], limit - 1)
       elsif response.is_a? Net::HTTPOK
         response

--- a/lib/linkscape/response.rb
+++ b/lib/linkscape/response.rb
@@ -10,6 +10,7 @@ module Linkscape
       attr_reader :type, :subjects
 
       class Flags
+        attr_reader :value
         def initialize(bitfield, type)
           @value = bitfield
           @flags = Linkscape::Constants::LinkMetrics::ResponseFlags.to_a.collect{|k,vv| k if (@value & vv[:flag]) == vv[:flag]}.compact if type == :link

--- a/lib/linkscape/signer.rb
+++ b/lib/linkscape/signer.rb
@@ -2,7 +2,7 @@ module Linkscape
   class Signer
     
     def self.signParams params, keysToSign=[:accessID, :expiration], key = nil
-      params[:expiration] ||= Time.now.to_i + 60
+      params[:expiration] ||= Time.now.to_i + 300
       stringToSign = keysToSign.collect{|k| params[k].to_s}.join("\n")
       key ||= params[:secretKey]
       signature = CGI::escape( Base64.encode64( HMAC::SHA1.digest( key, stringToSign ) ).chomp )


### PR DESCRIPTION
Linkscape can throw many types of errors (thanks to Net::HTTP), and
sometimes it can return a response that is not .valid? ... in consumers
we always check that the data is not nil and rescue all the errors...
this code should be located here in the gem rather than in the many
consumers.

Also, this commit fixes some appearently very broken redirection code
which we probably don't need anyway since Linkscape never redirects
AFAIK.

Not that this means that responses will probably always be .valid? (e.g.
500 errors now throw exceptions instead of returning a non-valid
response). We can probably get rid of the .valid? code and not use it
anymore in any consumers which may use it.

Because of this, and because this commit changes the exceptions which may
be thrown, this commit will break old code, which should be updated to
just rescue Linkscape::Error.
