### PR TITLE
add url_schema support for faraday branch

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -29,13 +29,12 @@ GEM
   remote: https://rubygems.org/
   specs:
     columnize (0.3.6)
-    debugger (1.3.0)
+    debugger (1.6.6)
       columnize (>= 0.3.1)
-      debugger-linecache (~> 1.1.1)
-      debugger-ruby_core_source (~> 1.1.7)
-    debugger-linecache (1.1.2)
-      debugger-ruby_core_source (>= 1.1.1)
-    debugger-ruby_core_source (1.1.7)
+      debugger-linecache (~> 1.2.0)
+      debugger-ruby_core_source (~> 1.3.2)
+    debugger-linecache (1.2.0)
+    debugger-ruby_core_source (1.3.2)
     diff-lcs (1.2.0)
     faraday (0.8.5)
       multipart-post (~> 1.1)

--- a/lib/linkscape/client.rb
+++ b/lib/linkscape/client.rb
@@ -36,7 +36,6 @@ module Linkscape
       Linkscape::Request.run(@options.merge(options))
     end
 
-
     def urlMetrics(*args)
       options = Hash === args.last ? args.pop.symbolize_keys : {}
       url = args.first ? args.shift : options[:url]
@@ -54,7 +53,6 @@ module Linkscape
 
       Linkscape::Request.run(@options.merge(options))
     end
-
 
     def topLinks(*args)
       options = Hash === args.last ? args.pop.symbolize_keys : {}
@@ -83,7 +81,6 @@ module Linkscape
 
       Linkscape::Request.run(@options.merge(options))
     end
-
 
     def allLinks(*args)
       options = Hash === args.last ? args.pop.symbolize_keys : {}
@@ -125,7 +122,6 @@ module Linkscape
 
       Linkscape::Request.run(@options.merge(options))
     end
-
 
     def topPages(*args)
       options = Hash === args.last ? args.pop.symbolize_keys : {}
@@ -194,7 +190,6 @@ module Linkscape
       Linkscape::Request.run(@options.merge(options))
     end
 
-
     def endpoint
       "#{@options[:apiHost]}/#{@options[:apiRoot]}"
     end
@@ -228,6 +223,5 @@ module Linkscape
 
       bits
     end
-
   end
 end

--- a/lib/linkscape/constants.rb
+++ b/lib/linkscape/constants.rb
@@ -27,7 +27,6 @@ module Linkscape
         :key => :canonical_internal_id,
         :desc => %Q[Internal ID of the canonical URL],
       },
-
       :us => {
         :name => 'HTTP Status',
         :key => :status,
@@ -38,7 +37,6 @@ module Linkscape
         :key => :title,
         :desc => %Q[The title of the target URL, if a title is available],
       },
-
       :ff => {
         :name => 'Time of Last FQ Domain Update',
         :key => :fq_domain_updated_at,
@@ -54,7 +52,6 @@ module Linkscape
         :key => :updated_at,
         :desc => %Q[The unix timestamp giving a rough idea of how fresh the data is of the target URL],
       },
-
       :fid => {
         :name => 'Number of Links to FQ Domain',
         :key => :fq_domain_fq_domains_linking,
@@ -105,7 +102,6 @@ module Linkscape
         :key => :external_links,
         :desc => %Q[The number of external (from other subdomains), juice passing links to the target URL in the Linkscape index],
       },
-
       :fejp => {
         :name => 'External mozRank sum of all FQ Domain Pages',
         :key => :fq_domain_external_mozrank_sum,
@@ -126,7 +122,6 @@ module Linkscape
         :key => :pl_domain_mozrank_sum,
         :desc => %Q[The pretty (logarithmically scaled) sum of the mozRank of all the pages of the PL domain of the target URL in the Linkscape index],
       },
-
       :fejr => {
         :name => 'External mozRank sum of all FQ Domain Pages (raw)',
         :key => :fq_domain_external_mozrank_sum_raw,
@@ -147,7 +142,6 @@ module Linkscape
         :key => :pl_domain_mozrank_sum_raw,
         :desc => %Q[The raw (linearly scaled) sum of the mozRank of all the pages of the PL domain of the target URL in the Linkscape index],
       },
-
       :fmrp => {
         :name => 'mozRank of FQ Domain',
         :key => :fq_domain_mozrank,
@@ -163,7 +157,6 @@ module Linkscape
         :key => :mozrank,
         :desc => %Q[The pretty (ten point, logarithmically scaled) measure of the mozRank of the target URL in the Linkscape index],
       },
-
       :fmrr => {
         :name => 'mozRank of FQ Domain (raw)',
         :key => :fq_domain_mozrank_raw,
@@ -179,7 +172,6 @@ module Linkscape
         :key => :mozrank_raw,
         :desc => %Q[The raw (zero to one, linearly scaled) measure of the mozRank of the target URL in the Linkscape index],
       },
-
       :ftrp => {
         :name => 'mozTrust of FQ Domain',
         :key => :fq_domain_moztrust,
@@ -210,7 +202,6 @@ module Linkscape
         :key => :moztrust_raw,
         :desc => %Q[The raw (zero to one, linearly scaled) measure of the mozTrust of the target URL in the Linkscape index],
       },
-
       :uemrp => {
         :name => 'External mozRank',
         :key => :external_mozrank,
@@ -241,7 +232,6 @@ module Linkscape
         :key => :pl_domain,
         :desc => %Q[The pay-level domain (PL domain) as it's identified in the Linkscape index],
       },
-      
       :ued => {
         :key => :all_external_links,
         :name => 'All external links page to page',
@@ -332,8 +322,6 @@ module Linkscape
         :name => 'Followed Cblock Linking Domain',
         :desc => %Q[The total number of cblock with followed links to a domain.]
       },
-      
-      
       :upa => {
         :name => 'Page Authority',
         :key => :page_authority,
@@ -354,14 +342,19 @@ module Linkscape
         :key => :domain_authority_raw,
         :desc => %Q[The raw (zero to one, linearly scaled) domain authority of the target URL's PL domain],
       },
-      
+      :usch => {
+        :name => 'URL schema (HTTP/HTTPS)',
+        :key => :url_schema,
+        :desc => %Q[Bit flags for: https present true/false, and https canonical true/false],
+      },
+
     }
+
     URLResponsePrefixes = {
       nil  => :source,
       :lu  => :target,
     }
-    
-    
+
     LinkResponseFields = {
       :t => {
         :name => 'Anchor Text',
@@ -405,11 +398,11 @@ module Linkscape
         :desc => %Q[The pretty (ten point, logarithmically scaled) measure of the mozRank passed to the target URL in the Linkscape index],
       },
     }
+
     LinkResponsePrefixes = {
       :l   => :link,
     }
-    
-    
+
     AnchorResponseFields = {
       :t => {
         :name => 'Anchor Text',
@@ -490,19 +483,19 @@ module Linkscape
       [:juice_internal_links,                       [ :juice_links,                  :external_links                     ]],
       [:internal_links,                             [ :links,                        :all_external_links                 ]],
       [:unfollowed_internal_links,                  [ :internal_links,               :juice_internal_links               ]],
-      
+
       [:fq_domain_unfollowed_external_links,        [ :fq_domain_all_external_links, :fq_domain_external_links           ]],
       [:fq_domain_unfollowed_links,                 [ :fq_domain_links,              :fq_domain_juice_links              ]],
       [:fq_domain_juice_internal_links,             [ :fq_domain_juice_links,        :fq_domain_external_links           ]],
       [:fq_domain_internal_links,                   [ :fq_domain_links,              :fq_domain_all_external_links       ]],
       [:fq_domain_unfollowed_internal_links,        [ :fq_domain_internal_links,     :fq_domain_juice_internal_links     ]],
-      
+
       [:pl_domain_unfollowed_external_links,        [ :pl_domain_all_external_links, :pl_domain_external_links           ]],
       [:pl_domain_unfollowed_links,                 [ :pl_domain_links,              :pl_domain_juice_links              ]],
       [:pl_domain_juice_internal_links,             [ :pl_domain_juice_links,        :pl_domain_external_links           ]],
       [:pl_domain_internal_links,                   [ :pl_domain_links,              :pl_domain_all_external_links       ]],
       [:pl_domain_unfollowed_internal_links,        [ :pl_domain_internal_links,     :pl_domain_juice_internal_links     ]],
-      
+
       [:unfollowed_fq_domains_linking,              [ :fq_domains_linking,           :juice_fq_domains_linking           ]],
       [:unfollowed_pl_domains_linking,              [ :pl_domains_linking,           :juice_pl_domains_linking           ]],
       [:fq_domain_unfollowed_fq_domains_linking,    [ :fq_domain_fq_domains_linking, :fq_domain_juice_fq_domains_linking ]],
@@ -514,7 +507,7 @@ module Linkscape
       [:pl_domain_unfollowed_ips_linking,           [ :pl_domain_ips_linking,        :pl_domain_juice_ips_linking        ]],
     ]
     ResponseFields = {}
-    
+
     URLResponsePrefixes.each do |prefix, subject|
       URLResponseFields.each do |k,v|
         v = v.dup.merge(
@@ -525,6 +518,7 @@ module Linkscape
         ResponseFields[v[:source]] = v
       end
     end
+
     LinkResponsePrefixes.each do |prefix, subject|
       LinkResponseFields.each do |k,v|
         v = v.dup.merge(
@@ -535,6 +529,7 @@ module Linkscape
         ResponseFields[v[:source]] = v
       end
     end
+
     AnchorResponsePrefixes.each do |prefix, subject|
       AnchorResponseFields.each do |k,v|
         v = v.dup.merge(
@@ -545,11 +540,10 @@ module Linkscape
         ResponseFields[v[:source]] = v
       end
     end
-    
+
     ResponseFields.keys.each {|k| ResponseFields[ResponseFields[k][:key]] ||= ResponseFields[k] if ResponseFields[k][:key] }
-    
+
     LongestNameLength = ResponseFields.collect{|k,v|v[:name].length}.max
     LongestKeyLength = ResponseFields.collect{|k,v|v[:key].to_s.length}.max
-    
   end
 end

--- a/lib/linkscape/constants/url-metrics.rb
+++ b/lib/linkscape/constants/url-metrics.rb
@@ -148,7 +148,6 @@ module Linkscape
           :flag => 2**29, # 536870912
           :desc => %Q[The HTTP status code recorded by Linkscape for this URL (if available)]
         },
-
         :page_authority => {
           :name => 'Page Authority',
           :flag => 2**35, # 34359738368
@@ -159,7 +158,16 @@ module Linkscape
           :flag => 2**36, # 68719476736
           :desc => %Q[The page authority of all pages on the root domain. This will return the pretty 100-point score.]
         },
-        
+        :page_authority_raw => {
+          :name => 'Raw Page Authority',
+          :flag => 2**37, # 137438953472
+          :desc => %Q[The page authority of this URL. This will return the raw score.]
+        },
+        :domain_authority_raw => {
+          :name => 'Raw Domain Authority',
+          :flag => 2**38, # 274877906944
+          :desc => %Q[The page authority of all pages on the root domain. This will return the raw score.]
+        },
         :all_external_links => {
           :name => 'All external links page to page',
           :flag => 2**39,
@@ -250,18 +258,12 @@ module Linkscape
           :flag => 2**56,
           :desc => %Q[The total number of cblock with followed links to a domain.]
         },
-        
-        :page_authority_raw => {
-          :name => 'Raw Page Authority',
-          :flag => 2**37, # 137438953472
-          :desc => %Q[The page authority of this URL. This will return the raw score.]
+        :url_schema => {
+          :name => 'URL schema (HTTP/HTTPS)',
+          :flag => 2**61,
+          :desc => 'If Mozscape has crawled HTTP and/or HTTPS'
         },
-        :domain_authority_raw => {
-          :name => 'Raw Domain Authority',
-          :flag => 2**38, # 274877906944
-          :desc => %Q[The page authority of all pages on the root domain. This will return the raw score.]
-        },
-        
+
         # The following are calculated values. If you ask for them,
         # we'll convert it into a request for the fields they
         # depend on. In the Response, we'll then set the key from
@@ -338,16 +340,36 @@ module Linkscape
         :pl_domain_unfollowed_ips_linking => {
           :flag => 2**53 | 2**54,
         },
-
-        
-
       }
+
       RequestBits[:all] = {
         :name => 'All columns',
         :flag => RequestBits.keys.inject(0) {|sum,k| sum | RequestBits[k][:flag]},
         :desc => %Q[Requests all known columns from the API]
       }
 
+      UrlSchemaFlags = {
+        :http_present => {
+          :name => 'HTTP present',
+          :flag => 2**0,
+          :desc => %Q[An HTTP version of the URL was found.]
+        },
+        :https_present => {
+          :name => 'HTTPS present',
+          :flag => 2**1,
+          :desc => %Q[An HTTPS version of the URL was found.]
+        },
+        :http_canonical => {
+          :name => 'HTTP canonical',
+          :flag => 2**24,
+          :desc => %Q[An HTTP version of the URL is canonical.]
+        },
+        :https_canonical => {
+          :name => 'HTTPS canonical',
+          :flag => 2**25,
+          :desc => %Q[An HTTPS version of the URL is canonical.]
+        },
+      }
     end
   end
 end

--- a/lib/linkscape/response.rb
+++ b/lib/linkscape/response.rb
@@ -2,11 +2,11 @@ require 'forwardable'
 module Linkscape
   class Response
     extend Forwardable
-    
+
     class ResponseData
       include Enumerable
       extend Forwardable
-      
+
       attr_reader :type, :subjects
 
       class Flags
@@ -33,10 +33,10 @@ module Linkscape
         elsif Array === @data
           :array
         end
-        
+
         @data.symbolize_keys! if Hash === @data
         @data = @data.collect{|d|ResponseData.new(d)} if Array === @data
-        
+
         if Hash === @data && !type.nil?
           Linkscape::Constants::CalculationKeyMap.each do |key, keys|
             unless @data[keys[0]].nil? or @data[keys[1]].nil?
@@ -44,7 +44,7 @@ module Linkscape
             end
           end
         end
-        
+
         if @type == :hash
           subdatas = {}
           @data.each do |k,v|
@@ -62,7 +62,6 @@ module Linkscape
             @subjects.push k
           end
         end
-        
       end
 
       def_delegators :@data, :length, :each, :each_index, :map, :collect, :select, :keys
@@ -80,7 +79,7 @@ module Linkscape
       rescue
         nil
       end
-      
+
       def to_s(indent="")
         printer = Proc.new do |h,prefix|
           o = ""
@@ -112,14 +111,13 @@ module Linkscape
         #<Linkscape::Response:0x10161d8a0 @response=#<Net::HTTPUnauthorized 401 Unauthorized readbody=true>>
         %Q[#<#{self.class} @type=#{@type.inspect}] + (@subjects ? %Q[ @subjects=#{@subjects.inspect}] : "") + %Q[>]
       end
-
     end
-    
+
     require 'rubygems'
     require 'json'
-    
+
     attr_accessor :request, :response, :data, :valid
-    
+
     def initialize(request, response)
       @valid = false
       @request = request
@@ -129,16 +127,14 @@ module Linkscape
         @valid = true
       end
     end
-    
+
     def_delegators :@data, :[], :length, :each, :each_index, :map, :collect, :select
-    
+
     def valid?; valid; end
-    
+
     def inspect
       #<Linkscape::Response:0x10161d8a0 @response=#<Net::HTTPUnauthorized 401 Unauthorized readbody=true>>
       %Q[#<#{self.class} @response.status=#{@response.status} @request="#{@request.requestURL}">]
     end
-    
   end
-  
 end


### PR DESCRIPTION
Adds support for the linkscape `usch` bitfield, delivered to the client as `url_schema`.

This PR also includes whitespace cleanup.
