### PR TITLE
Add support for "metadata" API call

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -114,6 +114,14 @@ This call accepts the following options:
 * <tt>:limit</tt> - The # of links (limit) you would like to return.
 * <tt>:offset</tt> = The number of records to offset before returning the 1st record of results.
 
+=== metadata
+
+Returns index statistics and release dates.
+
+  client.metadata(type)
+
+The parameter <tt>:type</tt> of this method can be either <tt>:last_update</tt>, <tt>:next_update</tt>, or <tt>:index_stats</tt>. It specifies the type of index metadata you are requesting.
+
 == Requesting Data on Multiple URLs
 
 For the API calls which support it, you may request data on multiple URLs by passing an

--- a/lib/linkscape/client.rb
+++ b/lib/linkscape/client.rb
@@ -179,8 +179,19 @@ module Linkscape
       Linkscape::Request.run(@options.merge(options))
     end
 
+    def metadata(*args)
+      options = Hash === args.last ? args.pop.symbolize_keys : {}
+      command = args.first ? args.shift : options[:command]
+      url_file_extension = :json unless command == :index_stats
 
+      valid_commands = [:last_update, :next_update, :index_stats]
+      raise InvalidArgument, "metadata command must be valid (#{valid_commands.join(', ')})" unless valid_commands.include? command
 
+      options[:api] = 'metadata'
+      options[:url] = "#{command.to_s}#{".#{url_file_extension.to_s}" unless url_file_extension.nil?}"
+
+      Linkscape::Request.run(@options.merge(options))
+    end
 
     def inspect
       %Q[#<#{self.class}:#{"0x%x" % self.object_id} api="#{@options[:apiHost]}/#{@options[:apiRoot]}" accessID="#{@options[:accessID]}">]

--- a/test.rb
+++ b/test.rb
@@ -41,3 +41,7 @@ do_request c.allLinks(url, :page, :domain, :domains_linking_page, :urlcols => [:
 do_request c.topPages(url, :page, :cols => :all, :limit => 3, :limit => 3)
 # 
 do_request c.anchorMetrics(url, :phrase, :page, :cols => :all, :scope => "page_to_domain", :filters => :external, :sort => :domains_linking_page, :limit => 3)
+
+do_request c.metadata(:last_update)
+do_request c.metadata(:next_update)
+do_request c.metadata(:index_stats)


### PR DESCRIPTION
This includes support for the following metadata types: "last_update",
"next_update", and "index_stats".
